### PR TITLE
process exits in case of port conflict

### DIFF
--- a/src/boot/boot.go
+++ b/src/boot/boot.go
@@ -47,6 +47,7 @@ func Run() {
 	logrus.Infof("ssaplayground: welcome to ssaplayground service... http://%s/gossa", config.Get().Addr)
 	err := server.ListenAndServe()
 	if err != http.ErrServerClosed {
+		terminated <- true
 		logrus.Info("ssaplayground: launch with error: ", err)
 	}
 


### PR DESCRIPTION
I found that when the port conflicts, the process will not exit, so I added this line of code